### PR TITLE
Add groupGrid fillingWidthAndHeightWithColumnCount method

### DIFF
--- a/Facade/UIView+Facade.h
+++ b/Facade/UIView+Facade.h
@@ -118,5 +118,6 @@
 #pragma mark - Grid
 
 - (void)groupGrid:(NSArray *)subviews fillingWidthWithColumnCount:(NSUInteger)columnCount spacing:(CGFloat)spacing;
+- (void)groupGrid:(NSArray *)subviews fillingWidthAndHeightWithColumnCount:(NSUInteger)columnCount spacing:(CGFloat)spacing;
 
 @end

--- a/Facade/UIView+Facade.m
+++ b/Facade/UIView+Facade.m
@@ -370,4 +370,32 @@
     }
 }
 
+#pragma mark - Grid
+
+- (void)groupGrid:(NSArray *)subviews fillingWidthAndHeightWithColumnCount:(NSUInteger)columnCount spacing:(CGFloat)spacing {
+    NSUInteger currentColumn = 0;
+    CGFloat xOrigin = spacing;
+    CGFloat yOrigin = spacing;
+    CGFloat width = (CGRectGetWidth(self.frame) - ((columnCount + 1) * spacing)) / (CGFloat)columnCount;
+    CGFloat height = CGRectGetHeight(self.frame);
+    CGFloat offset = width + spacing;
+    
+    for (UIView *subview in subviews) {
+        subview.frame = CGRectMake(xOrigin, yOrigin, width, height);
+        
+        if (currentColumn == columnCount - 1) {
+            currentColumn = 0;
+            
+            xOrigin = spacing;
+            yOrigin += offset;
+        }
+        
+        else {
+            currentColumn++;
+            
+            xOrigin += offset;
+        }
+    }
+}
+
 @end


### PR DESCRIPTION
groupGrid fillingWidthWithColumnCount produces inconsistent height when the screen is rotated for fixed height elements. The width size is being calculated to distribute the items evenly and the same calculated value is being used for height parameter in CGRectMake. This is not true for elements who has fixed height but needs to be distributed evenly through their parents width. Please check the attached screen shots.

In Portrait Mode : All is good
![screen shot 2015-07-01 at 8 58 36 am](https://cloud.githubusercontent.com/assets/978347/8456258/e3e44eae-1fcf-11e5-8f6c-a5ff6ec3efe2.png)

Using groupGrid fillingWidthWithColumnCount method in Landscape Mode: Inconsistent height
![screen shot 2015-07-01 at 8 59 42 am](https://cloud.githubusercontent.com/assets/978347/8456304/33dfb696-1fd0-11e5-8ffd-41d3a413e50e.png)

groupGrid fillingWidthAndHeightWithColumnCount method in Landscape Mode: All is good
![screen shot 2015-07-01 at 8 59 00 am](https://cloud.githubusercontent.com/assets/978347/8456320/40bfceb4-1fd0-11e5-81da-a93e6c5bcdac.png)
